### PR TITLE
Refactor statuses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mongoose-subscriptions",
-    "version": "1.2.2",
+    "version": "1.3.2",
     "description": "Processor agnostic payment subscription backend",
     "main": "src/index.js",
     "repository": "git@github.com:enhancv/mongoose-subscriptions.git",

--- a/src/Schema/Customer.js
+++ b/src/Schema/Customer.js
@@ -4,6 +4,7 @@ const PaymentMethod = require('./PaymentMethod');
 const Subscription = require('./Subscription');
 const Transaction = require('./Transaction');
 const ProcessorItem = require('./ProcessorItem');
+const SubscriptionStatus = require('./Statuses/SubscriptionStatus');
 
 const Schema = mongoose.Schema;
 
@@ -83,7 +84,7 @@ Customer.methods.activeSubscriptions = function activeSubscriptions(activeDate) 
     const date = activeDate || new Date();
 
     return this.populate().subscriptions
-        .filter(item => item.paidThroughDate >= date && item.status === 'Active')
+        .filter(item => item.paidThroughDate >= date && item.status.status === SubscriptionStatus.ACTIVE)
         .sort((a, b) => b.plan.level - a.plan.level);
 };
 

--- a/src/Schema/Customer.js
+++ b/src/Schema/Customer.js
@@ -84,7 +84,7 @@ Customer.methods.activeSubscriptions = function activeSubscriptions(activeDate) 
     const date = activeDate || new Date();
 
     return this.populate().subscriptions
-        .filter(item => item.paidThroughDate >= date && item.status.status === SubscriptionStatus.ACTIVE)
+        .filter(item => item.paidThroughDate >= date && item.status === SubscriptionStatus.ACTIVE)
         .sort((a, b) => b.plan.level - a.plan.level);
 };
 

--- a/src/Schema/Statuses/SubscriptionStatus.js
+++ b/src/Schema/Statuses/SubscriptionStatus.js
@@ -1,0 +1,25 @@
+const mongoose = require('mongoose');
+
+const Schema = mongoose.Schema;
+
+const ACTIVE = 'Active';
+const CANCELED = 'Canceled';
+const EXPIRED = 'Expired';
+const PAST_DUE = 'Past Due';
+const PENDING = 'Pending';
+
+const SubscriptionStatus = new Schema({
+    status: {
+        type: String,
+        enum: [ACTIVE, CANCELED, EXPIRED, PAST_DUE, PENDING],
+    },
+    timestamp: Date,
+}, { _id: false });
+
+SubscriptionStatus.ACTIVE = ACTIVE;
+SubscriptionStatus.CANCELED = CANCELED;
+SubscriptionStatus.EXPIRED = EXPIRED;
+SubscriptionStatus.PAST_DUE = PAST_DUE;
+SubscriptionStatus.PENDING = PENDING;
+
+module.exports = SubscriptionStatus;

--- a/src/Schema/Statuses/SubscriptionStatus.js
+++ b/src/Schema/Statuses/SubscriptionStatus.js
@@ -8,10 +8,12 @@ const EXPIRED = 'Expired';
 const PAST_DUE = 'Past Due';
 const PENDING = 'Pending';
 
+const statuses = [ACTIVE, CANCELED, EXPIRED, PAST_DUE, PENDING];
+
 const SubscriptionStatus = new Schema({
     status: {
         type: String,
-        enum: [ACTIVE, CANCELED, EXPIRED, PAST_DUE, PENDING],
+        enum: statuses,
     },
     timestamp: Date,
 }, { _id: false });
@@ -21,5 +23,7 @@ SubscriptionStatus.CANCELED = CANCELED;
 SubscriptionStatus.EXPIRED = EXPIRED;
 SubscriptionStatus.PAST_DUE = PAST_DUE;
 SubscriptionStatus.PENDING = PENDING;
+
+SubscriptionStatus.Statuses = statuses;
 
 module.exports = SubscriptionStatus;

--- a/src/Schema/Statuses/TransactionStatus.js
+++ b/src/Schema/Statuses/TransactionStatus.js
@@ -16,24 +16,26 @@ const SETTLING = 'settling';
 const SUBMITTED_FOR_SETTLEMENT = 'submitted_for_settlement';
 const VOIDED = 'voided';
 
+const statuses = [
+    AUTHORIZATION_EXPIRED,
+    AUTHORIZED,
+    AUTHORIZING,
+    SETTLEMENT_PENDING,
+    SETTLEMENT_CONFIRMED,
+    SETTLEMENT_DECLINED,
+    FAILED,
+    GATEWAY_REJECTED,
+    PROCESSOR_DECLINED,
+    SETTLED,
+    SETTLING,
+    SUBMITTED_FOR_SETTLEMENT,
+    VOIDED,
+];
+
 const TransactionStatus = new Schema({
     status: {
         type: String,
-        enum: [
-            AUTHORIZATION_EXPIRED,
-            AUTHORIZED,
-            AUTHORIZING,
-            SETTLEMENT_PENDING,
-            SETTLEMENT_CONFIRMED,
-            SETTLEMENT_DECLINED,
-            FAILED,
-            GATEWAY_REJECTED,
-            PROCESSOR_DECLINED,
-            SETTLED,
-            SETTLING,
-            SUBMITTED_FOR_SETTLEMENT,
-            VOIDED,
-        ],
+        enum: statuses,
     },
     timestamp: Date,
 }, { _id: false });
@@ -51,5 +53,7 @@ TransactionStatus.SETTLED = SETTLED;
 TransactionStatus.SETTLING = SETTLING;
 TransactionStatus.SUBMITTED_FOR_SETTLEMENT = SUBMITTED_FOR_SETTLEMENT;
 TransactionStatus.VOIDED = VOIDED;
+
+TransactionStatus.Statuses = statuses;
 
 module.exports = TransactionStatus;

--- a/src/Schema/Statuses/TransactionStatus.js
+++ b/src/Schema/Statuses/TransactionStatus.js
@@ -1,0 +1,55 @@
+const mongoose = require('mongoose');
+
+const Schema = mongoose.Schema;
+
+const AUTHORIZATION_EXPIRED = 'authorization_expired';
+const AUTHORIZED = 'authorized';
+const AUTHORIZING = 'authorizing';
+const SETTLEMENT_PENDING = 'settlement_pending';
+const SETTLEMENT_CONFIRMED = 'settlement_confirmed';
+const SETTLEMENT_DECLINED = 'settlement_declined';
+const FAILED = 'failed';
+const GATEWAY_REJECTED = 'gateway_rejected';
+const PROCESSOR_DECLINED = 'processor_declined';
+const SETTLED = 'settled';
+const SETTLING = 'settling';
+const SUBMITTED_FOR_SETTLEMENT = 'submitted_for_settlement';
+const VOIDED = 'voided';
+
+const TransactionStatus = new Schema({
+    status: {
+        type: String,
+        enum: [
+            AUTHORIZATION_EXPIRED,
+            AUTHORIZED,
+            AUTHORIZING,
+            SETTLEMENT_PENDING,
+            SETTLEMENT_CONFIRMED,
+            SETTLEMENT_DECLINED,
+            FAILED,
+            GATEWAY_REJECTED,
+            PROCESSOR_DECLINED,
+            SETTLED,
+            SETTLING,
+            SUBMITTED_FOR_SETTLEMENT,
+            VOIDED,
+        ],
+    },
+    timestamp: Date,
+}, { _id: false });
+
+TransactionStatus.AUTHORIZATION_EXPIRED = AUTHORIZATION_EXPIRED;
+TransactionStatus.AUTHORIZED = AUTHORIZED;
+TransactionStatus.AUTHORIZING = AUTHORIZING;
+TransactionStatus.SETTLEMENT_PENDING = SETTLEMENT_PENDING;
+TransactionStatus.SETTLEMENT_CONFIRMED = SETTLEMENT_CONFIRMED;
+TransactionStatus.SETTLEMENT_DECLINED = SETTLEMENT_DECLINED;
+TransactionStatus.FAILED = FAILED;
+TransactionStatus.GATEWAY_REJECTED = GATEWAY_REJECTED;
+TransactionStatus.PROCESSOR_DECLINED = PROCESSOR_DECLINED;
+TransactionStatus.SETTLED = SETTLED;
+TransactionStatus.SETTLING = SETTLING;
+TransactionStatus.SUBMITTED_FOR_SETTLEMENT = SUBMITTED_FOR_SETTLEMENT;
+TransactionStatus.VOIDED = VOIDED;
+
+module.exports = TransactionStatus;

--- a/src/Schema/Subscription.js
+++ b/src/Schema/Subscription.js
@@ -4,7 +4,7 @@ const ProcessorItem = require('./ProcessorItem');
 const Descriptor = require('./Descriptor');
 const originals = require('mongoose-originals');
 const Discount = require('./Discount');
-const Status = require('./Status');
+const SubscriptionStatus = require('./Statuses/SubscriptionStatus');
 
 const Schema = mongoose.Schema;
 
@@ -28,9 +28,11 @@ const Subscription = new Schema({
     firstBillingDate: Date,
     nextBillingDate: Date,
     paidThroughDate: Date,
-    status: String,
+    status: {
+        type: SubscriptionStatus,
+    },
     price: Number,
-    statusHistory: [Status],
+    statusHistory: [SubscriptionStatus],
     descriptor: Descriptor,
     trialDuration: Number,
     trialDurationUnit: {

--- a/src/Schema/Subscription.js
+++ b/src/Schema/Subscription.js
@@ -29,7 +29,8 @@ const Subscription = new Schema({
     nextBillingDate: Date,
     paidThroughDate: Date,
     status: {
-        type: SubscriptionStatus,
+        type: String,
+        enum: SubscriptionStatus.Statuses,
     },
     price: Number,
     statusHistory: [SubscriptionStatus],

--- a/src/Schema/Transaction.js
+++ b/src/Schema/Transaction.js
@@ -2,7 +2,7 @@ const mongoose = require('mongoose');
 const ProcessorItem = require('./ProcessorItem');
 const TransactionAddress = require('./Transaction/Address');
 const TransactionCustomer = require('./Transaction/Customer');
-const Status = require('./Status');
+const TransactionStatus = require('./Statuses/TransactionStatus');
 const TransactionDiscount = require('./Transaction/Discount');
 const Descriptor = require('./Descriptor');
 const CreditCard = require('./Transaction/CreditCard');
@@ -36,10 +36,12 @@ const Transaction = new Schema({
     discounts: [TransactionDiscount],
     descriptor: Descriptor,
     customer: TransactionCustomer,
-    status: String,
+    status: {
+        type: TransactionStatus,
+    },
     createdAt: Date,
     updatedAt: Date,
-    statusHistory: [Status],
+    statusHistory: [TransactionStatus],
 });
 
 Transaction.TransactionCreditCard = CreditCard;

--- a/src/Schema/Transaction.js
+++ b/src/Schema/Transaction.js
@@ -37,7 +37,8 @@ const Transaction = new Schema({
     descriptor: Descriptor,
     customer: TransactionCustomer,
     status: {
-        type: TransactionStatus,
+        type: String,
+        enum: TransactionStatus.Statuses,
     },
     createdAt: Date,
     updatedAt: Date,

--- a/test/Schema/CustomerTest.js
+++ b/test/Schema/CustomerTest.js
@@ -54,7 +54,9 @@ describe('Customer', database([Customer], function () {
                     _id: 'four',
                     plan: this.plan,
                     processor: { id: 'id-subscription', state: 'saved' },
-                    status: 'Active',
+                    status: {
+                        status: 'Active'
+                    },
                     descriptor: {
                         name: 'Enhancv*Pro Plan',
                         phone: '0888415433',
@@ -183,28 +185,28 @@ describe('Customer', database([Customer], function () {
     const activeSubs = [
         {
             name: 'Only one sub',
-            subs: [{ id: 1, level: 2, status: 'Active', paidThroughDate: '2017-02-02'}],
+            subs: [{ id: 1, level: 2, status: { status: 'Active' }, paidThroughDate: '2017-02-02'}],
             expected: [1],
             expectedActive: 1,
         },
         {
             name: 'With expired sub',
-            subs: [{ id: 1, level: 2, status: 'Active', paidThroughDate: '2017-01-01'}],
+            subs: [{ id: 1, level: 2, status: { status: 'Active' }, paidThroughDate: '2017-01-01'}],
             expected: [],
             expectedActive: null,
         },
         {
             name: 'With non-active sub',
-            subs: [{ id: 1, level: 2, status: 'Past Due', paidThroughDate: '2017-02-02'}],
+            subs: [{ id: 1, level: 2, status: { status: 'Past Due' }, paidThroughDate: '2017-02-02'}],
             expected: [],
             expectedActive: null,
         },
         {
             name: 'Correct level order',
             subs: [
-                { id: 3, level: 3, status: 'Active', paidThroughDate: '2017-02-02'},
-                { id: 1, level: 1, status: 'Active', paidThroughDate: '2017-02-02'},
-                { id: 2, level: 2, status: 'Active', paidThroughDate: '2017-02-02'},
+                { id: 3, level: 3, status: { status: 'Active' }, paidThroughDate: '2017-02-02'},
+                { id: 1, level: 1, status: { status: 'Active' }, paidThroughDate: '2017-02-02'},
+                { id: 2, level: 2, status: { status: 'Active' }, paidThroughDate: '2017-02-02'},
             ],
             expected: [3, 2, 1],
             expectedActive: 3,

--- a/test/Schema/CustomerTest.js
+++ b/test/Schema/CustomerTest.js
@@ -54,9 +54,7 @@ describe('Customer', database([Customer], function () {
                     _id: 'four',
                     plan: this.plan,
                     processor: { id: 'id-subscription', state: 'saved' },
-                    status: {
-                        status: 'Active'
-                    },
+                    status: 'Active',
                     descriptor: {
                         name: 'Enhancv*Pro Plan',
                         phone: '0888415433',
@@ -185,28 +183,28 @@ describe('Customer', database([Customer], function () {
     const activeSubs = [
         {
             name: 'Only one sub',
-            subs: [{ id: 1, level: 2, status: { status: 'Active' }, paidThroughDate: '2017-02-02'}],
+            subs: [{ id: 1, level: 2, status: 'Active', paidThroughDate: '2017-02-02'}],
             expected: [1],
             expectedActive: 1,
         },
         {
             name: 'With expired sub',
-            subs: [{ id: 1, level: 2, status: { status: 'Active' }, paidThroughDate: '2017-01-01'}],
+            subs: [{ id: 1, level: 2, status: 'Active', paidThroughDate: '2017-01-01'}],
             expected: [],
             expectedActive: null,
         },
         {
             name: 'With non-active sub',
-            subs: [{ id: 1, level: 2, status: { status: 'Past Due' }, paidThroughDate: '2017-02-02'}],
+            subs: [{ id: 1, level: 2, status: 'Past Due', paidThroughDate: '2017-02-02'}],
             expected: [],
             expectedActive: null,
         },
         {
             name: 'Correct level order',
             subs: [
-                { id: 3, level: 3, status: { status: 'Active' }, paidThroughDate: '2017-02-02'},
-                { id: 1, level: 1, status: { status: 'Active' }, paidThroughDate: '2017-02-02'},
-                { id: 2, level: 2, status: { status: 'Active' }, paidThroughDate: '2017-02-02'},
+                { id: 3, level: 3, status: 'Active', paidThroughDate: '2017-02-02'},
+                { id: 1, level: 1, status: 'Active', paidThroughDate: '2017-02-02'},
+                { id: 2, level: 2, status: 'Active', paidThroughDate: '2017-02-02'},
             ],
             expected: [3, 2, 1],
             expectedActive: 3,

--- a/test/Schema/SubscriptionTest.js
+++ b/test/Schema/SubscriptionTest.js
@@ -30,9 +30,7 @@ describe('Subscription', function () {
                 level: 2,
             },
             processor: { id: 'id-subscription', state: 'saved' },
-            status: {
-                status: 'Active'
-            },
+            status: 'Active',
             discounts: [{
                 __t: 'DiscountAmount',
                 amount: 10,

--- a/test/Schema/SubscriptionTest.js
+++ b/test/Schema/SubscriptionTest.js
@@ -30,7 +30,9 @@ describe('Subscription', function () {
                 level: 2,
             },
             processor: { id: 'id-subscription', state: 'saved' },
-            status: 'Active',
+            status: {
+                status: 'Active'
+            },
             discounts: [{
                 __t: 'DiscountAmount',
                 amount: 10,


### PR DESCRIPTION
I think we should be more consistent so I've made those refactors

- Extract Transaction and Subscription statuses into separate models
- Use those models in Subscription and Transaction schemas where they are used (before we used Status model for the history only but not for the current status)